### PR TITLE
Adding an option to suppress log messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Most TypeScript-related options should be set using a
 file. There are a few loader-specific options you can set although in general
 you should not need to.
 
+##### silent *(boolean) (default='false')*
+If true, no console.log messages will be emitted.
+
 ##### compiler *(string) (default='typescript')*
 
 Allows use of TypeScript compilers other than the official one. Should be

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ interface Dependency {
 }
 
 interface Options {
+    silent: boolean;
     instance: string;
     compiler: string;
     configFileName: string;
@@ -86,6 +87,12 @@ function findConfigFile(compiler: typeof typescript, searchPath: string, configF
 
 function ensureTypeScriptInstance(options: Options, loader: any): TSInstance {
 
+    function log(...messages: string[]): void {
+        if (!options.silent) {
+            console.log.apply(console, messages);
+        }
+    }
+
     var compiler = require(options.compiler);
     var files = <TSFiles>{};
     
@@ -100,7 +107,7 @@ function ensureTypeScriptInstance(options: Options, loader: any): TSInstance {
     var filesToLoad = [];
     var configFilePath = findConfigFile(compiler, path.dirname(loader.resourcePath), options.configFileName);
     if (configFilePath) {
-        console.log('Using config file at '.green + configFilePath.blue);
+        log('Using config file at '.green + configFilePath.blue);
         var configFile = compiler.readConfigFile(configFilePath);
         // TODO: when 1.5 stable comes out, this will never be undefined. Instead it will
         // have an 'error' property
@@ -166,7 +173,7 @@ function ensureTypeScriptInstance(options: Options, loader: any): TSInstance {
         getCompilationSettings: () => compilerOptions,
         getDefaultLibFileName: options => libFileName,
         getNewLine: () => { return os.EOL },
-        log: message => console.log(message)
+        log: log
     };
 
     var languageService = compiler.createLanguageService(servicesHost, compiler.createDocumentRegistry())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In my project, I run `webpack` from the shell, and expect its output to be valid json. Having this module log to the console breaks the json parsing. In another context, I am spawning a process that where running this causes a console log that breaks the TAP output. In both cases, I would like the ability to turn off the logging.

I thought about adding a test but it seems like it would be quite a bit of work, and I'm not sure it's a good ROI.

Thanks for making this module!